### PR TITLE
Max width on select in quick-search

### DIFF
--- a/production/dwarf/stylesheets/application.css
+++ b/production/dwarf/stylesheets/application.css
@@ -658,6 +658,8 @@ body.controller-welcome.action-index #wrapper3 #main {
     box-sizing: border-box; }
     #header #quick-search > form {
       float: left; }
+    #header #quick-search select {
+      max-width: 100%; }
     #header #quick-search label {
       padding: 0px 10px;
       background-color: #282828;


### PR DESCRIPTION
I have very long project name, and default select is long as longest option. With "max-width: 100%" cannot be longer that block.